### PR TITLE
Added "MACs" option to ssh options table

### DIFF
--- a/library/src/ssh.c
+++ b/library/src/ssh.c
@@ -132,6 +132,10 @@ gint wsh_ssh_init(void) {
 	                           (gpointer)SSH_OPTIONS_KEY_EXCHANGE);
 	(void) g_hash_table_insert(ssh_opt_table, "gssapidelegatecredentials",
 	                           (gpointer)SSH_OPTIONS_GSSAPI_DELEGATE_CREDENTIALS);
+#if LIBSSH_VERSION_INT >= SSH_VERSION_INT(0, 8, 0)
+	(void) g_hash_table_insert(ssh_opt_table, "macs",
+	                           (gpointer)SSH_OPTIONS_HMAC_S_C);
+#endif
 
 #ifdef DEBUG
 	char* filename = getenv("WSH_SSH_PCAP");


### PR DESCRIPTION
Permits preventing an indefinite hang when handing control to libssh.

Added this for an issue unrelated to wsh: Older sshd instances might only
support obselete MAC algorithms (e.g.  hmac-sha1 or hmac-md5). If either the
client or server doesn't support a particular HMAC, the behavior appears to be
to block indefinitely... If the list is explicit about the supported algos, the
connection (correctly) fails immediately.

e.g. option usage:  --ssh-opt "macs=hmac-sha2-256"