### PR TITLE
Treat partial authentication as an error

### DIFF
--- a/library/src/ssh.c
+++ b/library/src/ssh.c
@@ -301,6 +301,11 @@ gint wsh_ssh_authenticate(wsh_ssh_session_t* session, GError** err) {
 					                   "Error authenticating with pubkey: %s",
 					                   ssh_get_error(session->session));
 					goto wsh_ssh_authenticate_failure;
+				case SSH_AUTH_PARTIAL:
+					*err = g_error_new(WSH_SSH_ERROR, WSH_SSH_PUBKEY_AUTH_ERR,
+					                   "Partial authentication with pubkey: %s",
+					                   ssh_get_error(session->session));
+					goto wsh_ssh_authenticate_failure;
 				case SSH_AUTH_DENIED:
 					pubkey_denied = TRUE;
 				default:


### PR DESCRIPTION
This fixes a downstream segmentation fault where wsh_ssh_authenticate returns
with a non-zero value but with a null GError pointer. In other words,
downstream error handling expects a GError object when the function reports
having error'd.

An improved implementation might break only on SSH_AUTH_SUCCESS.

See Also: https://www.rust-lang.org/